### PR TITLE
CI 環境でのテスト認証トークンを修正

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineWorkersConfig(async () => {
 					miniflare: {
 						bindings: {
 							TEST_MIGRATIONS: migrations,
+							AUTH_TOKEN: "test-token",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
- `.dev.vars` は `.gitignore` に含まれるため CI 環境では `AUTH_TOKEN` が未定義
- `vitest.config.ts` の `miniflare.bindings` にテスト用トークンを明示的に設定

## Test plan
- [ ] CI の test ジョブが成功すること
- [ ] ローカルテストが引き続き通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)