### PR TITLE
セッション詳細ページ（タイムラインビュー）を追加

### DIFF
--- a/docs/plan/v0.6.0.md
+++ b/docs/plan/v0.6.0.md
@@ -1,0 +1,149 @@
+# v0.6.0 セッション詳細ページ（タイムラインビュー）
+
+## Context
+
+Issue #7。セッション内の全イベントを時系列で表示する新ページ。
+データ基盤（#6）はマージ済みで、5つのイベントテーブル（api_requests, tool_results, user_prompts, tool_decisions, api_errors）と sessions テーブルが利用可能。
+
+**ゴール**: `GET /session/:id` で全イベントをカード形式のタイムラインとして表示
+**スコープ外**: ページネーション、リポジトリフィルタ（#8）、クライアント JS
+
+---
+
+## 設計判断
+
+| # | 判断 | 理由 |
+|---|------|------|
+| D1 | 5テーブル並列クエリ → アプリ層でマージ・ソート | UNION ALL はスキーマ差が大きく複雑。既存の `Promise.all` パターンに合致 |
+| D2 | `TimelineEvent` 判別共用体を `src/queries/session.ts` に定義 | `ParsedLogEvent`（OTLP パーサー用）と責務が異なる。DB行→表示用の型 |
+| D3 | format ヘルパーを `src/lib/format.ts` に抽出 | `formatCost` 等が Overview.tsx と RecentSessions.tsx で重複。セッション詳細でも使う |
+| D4 | セッション不在時は 404 HTML | `sessions` テーブルで存在確認。API ではなく SSR ページなので HTML で返す |
+| D5 | リンクは単純に `/session/{id}` | ダッシュボードの認証は Cloudflare Access が担当。トークン引き回し不要 |
+
+---
+
+## タスク
+
+### タスク 0: 計画ファイル保存 + ブランチ作成
+
+`docs/plan/v0.6.0.md` に計画を保存。`feature/session-detail-page` ブランチを main から作成。
+
+---
+
+### タスク 1: format ヘルパーの共通化
+
+**変更対象**:
+- `src/lib/format.ts`（新規）
+- `src/lib/format.test.ts`（新規）
+- `src/components/RecentSessions.tsx`（import 変更）
+- `src/components/Overview.tsx`（import 変更）
+- `src/components/DailyCosts.tsx`（import 変更、`formatCost` 使用箇所を確認）
+
+**I/O シグネチャ**:
+```typescript
+formatCost(usd: number) → string          // "$0.0123"
+formatTokens(n: number) → string           // "1.5M" / "1.5K" / "999"
+formatTime(ms: number) → string            // "2025-01-15 12:00:00"
+formatDuration(firstMs: number, lastMs: number) → string  // "2m"
+formatDurationMs(ms: number) → string      // "1.5s" / "150ms"（新規、単一duration用）
+```
+
+**受入条件**:
+- WHEN `formatCost(0.0123)` THEN `"$0.0123"`
+- WHEN `formatTokens(1_500_000)` THEN `"1.5M"`
+- WHEN `formatTokens(1500)` THEN `"1.5K"`
+- WHEN `formatTokens(999)` THEN `"999"`
+- WHEN `formatDurationMs(1500)` THEN `"1.5s"`
+- WHEN `formatDurationMs(150)` THEN `"150ms"`
+- WHEN `formatDurationMs(0)` THEN `"0ms"`
+- WHEN 既存テスト・型チェック THEN パス（リグレッションなし）
+
+---
+
+### タスク 2: セッションクエリ層
+
+**変更対象**:
+- `src/queries/session.ts`（新規）
+- `src/queries/session.test.ts`（新規）
+
+**I/O シグネチャ**:
+```typescript
+type SessionInfo = {
+  sessionId: string;
+  repository: string | null;
+  firstEventAt: number;
+  lastEventAt: number;
+};
+
+type TimelineEvent =
+  | { type: "user_prompt"; eventSequence: number | null; timestampMs: number; promptLength: number; prompt: string | null }
+  | { type: "api_request"; eventSequence: number | null; timestampMs: number; model: string; costUsd: number; durationMs: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number }
+  | { type: "tool_result"; eventSequence: number | null; timestampMs: number; toolName: string; success: boolean; durationMs: number; error: string | null; toolParameters: string | null }
+  | { type: "tool_decision"; eventSequence: number | null; timestampMs: number; toolName: string; decision: string; source: string | null }
+  | { type: "api_error"; eventSequence: number | null; timestampMs: number; model: string | null; error: string; statusCode: number | null; durationMs: number; attempt: number };
+
+getSessionInfo(db: D1Database, sessionId: string) → Promise<SessionInfo | null>
+getSessionTimeline(db: D1Database, sessionId: string) → Promise<TimelineEvent[]>
+```
+
+`getSessionTimeline` は 5 テーブルを `Promise.all` で並列クエリし、結果をマージして `event_sequence`（null は末尾）→ `timestamp_ms` でソート。
+
+**受入条件**:
+- WHEN 存在する sessionId THEN `SessionInfo` を返す
+- WHEN 存在しない sessionId THEN `null` を返す
+- WHEN 5テーブルすべてにイベントがある THEN 全イベントが event_sequence → timestamp_ms 順で返る
+- WHEN event_sequence が null THEN timestamp_ms でソートされ、非 null の後に配置
+- WHEN 1テーブルのみにイベント THEN そのイベントのみ返る
+- WHEN イベントが0件 THEN 空配列を返す
+- WHEN tool_result の success = 1 THEN `success === true`
+
+**依存**: なし（型は自己完結）
+
+---
+
+### タスク 3: タイムラインコンポーネント
+
+**変更対象**:
+- `src/components/SessionTimeline.tsx`（新規）
+
+**I/O シグネチャ**:
+```typescript
+SessionTimeline(props: { session: SessionInfo; events: TimelineEvent[] }) → JSX.Element
+```
+
+**イベントカード表示仕様**:
+
+| イベント | アクセント色 | 表示フィールド |
+|---------|------------|--------------|
+| user_prompt | blue | 文字数。`prompt` 非 null なら `<details>` で全文表示 |
+| api_request | green | モデル、コスト、トークン（in/out/cache）、所要時間 |
+| tool_result | 成功: green / 失敗: red | ツール名、成功/失敗バッジ、所要時間。Bash + toolParameters なら command 表示 |
+| tool_decision | yellow | ツール名、accept/reject バッジ、source |
+| api_error | red | モデル、エラー、ステータスコード、所要時間、attempt |
+
+**受入条件**:
+- WHEN events 非空 THEN セッションヘッダー（ID, リポジトリ, 期間）+ イベントカードを時系列表示
+- WHEN user_prompt で prompt 非 null THEN `<details>` で全文展開可能
+- WHEN user_prompt で prompt null THEN 文字数のみ表示
+- WHEN tool_result で toolName="Bash" かつ toolParameters に command THEN コマンド表示
+- WHEN tool_result で toolParameters が不正 JSON THEN クラッシュせず表示
+- WHEN events 空 THEN "No events found" メッセージ
+- WHEN レンダリング THEN ダークテーマ（bg-gray-900 等）で既存と統一
+
+**依存**: タスク 1（format ヘルパー）、タスク 2（型定義）
+
+---
+
+### タスク 4: ルート登録 + RecentSessions リンク
+
+**変更対象**:
+- `src/routes/dashboard.tsx`（`GET /session/:id` 追加）
+- `src/components/RecentSessions.tsx`（session ID を `<a>` リンク化）
+
+**受入条件**:
+- WHEN `GET /session/{existingId}` THEN 200 + タイムライン HTML
+- WHEN `GET /session/{nonExistentId}` THEN 404 + エラーページ HTML
+- WHEN RecentSessions テーブル THEN session ID が `/session/{id}` へのリンク
+- WHEN セッション詳細ページ THEN ダッシュボードへの戻りリンクあり
+
+**依存**: タスク 2, タスク 3

--- a/src/components/DailyCosts.tsx
+++ b/src/components/DailyCosts.tsx
@@ -1,9 +1,6 @@
+import { formatCost } from "../lib/format";
 import type { DailyCostRow } from "../queries/dashboard";
 import { DailyCostChart } from "./charts/DailyCostChart";
-
-function formatCost(usd: number): string {
-	return `$${usd.toFixed(4)}`;
-}
 
 export function DailyCosts({ rows }: { rows: DailyCostRow[] }) {
 	if (rows.length === 0) {

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -1,14 +1,5 @@
+import { formatCost, formatTokens } from "../lib/format";
 import type { OverviewStats } from "../queries/dashboard";
-
-function formatCost(usd: number): string {
-	return `$${usd.toFixed(4)}`;
-}
-
-function formatTokens(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-	return String(n);
-}
 
 function Card({
 	label,

--- a/src/components/RecentSessions.tsx
+++ b/src/components/RecentSessions.tsx
@@ -1,26 +1,10 @@
+import {
+	formatCost,
+	formatDuration,
+	formatTime,
+	formatTokens,
+} from "../lib/format";
 import type { SessionRow } from "../queries/dashboard";
-
-function formatCost(usd: number): string {
-	return `$${usd.toFixed(4)}`;
-}
-
-function formatTokens(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-	return String(n);
-}
-
-function formatTime(ms: number): string {
-	const d = new Date(ms);
-	return d.toISOString().replace("T", " ").slice(0, 19);
-}
-
-function formatDuration(firstMs: number, lastMs: number): string {
-	const diff = lastMs - firstMs;
-	if (diff < 60_000) return `${Math.round(diff / 1000)}s`;
-	if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m`;
-	return `${(diff / 3_600_000).toFixed(1)}h`;
-}
 
 export function RecentSessions({ sessions }: { sessions: SessionRow[] }) {
 	if (sessions.length === 0) {
@@ -52,7 +36,12 @@ export function RecentSessions({ sessions }: { sessions: SessionRow[] }) {
 						{sessions.map((s) => (
 							<tr key={s.sessionId} class="border-b border-gray-800">
 								<td class="px-4 py-2 font-mono text-xs max-w-[200px] truncate">
-									{s.sessionId}
+									<a
+										href={`/session/${s.sessionId}`}
+										class="text-blue-400 hover:text-blue-300 hover:underline"
+									>
+										{s.sessionId}
+									</a>
 								</td>
 								<td class="px-4 py-2 text-right">{formatCost(s.totalCost)}</td>
 								<td class="px-4 py-2 text-right">

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -1,0 +1,260 @@
+import {
+	formatCost,
+	formatDuration,
+	formatDurationMs,
+	formatTime,
+	formatTokens,
+} from "../lib/format";
+import type { SessionInfo, TimelineEvent } from "../queries/session";
+
+function Badge({
+	label,
+	color,
+}: { label: string; color: "green" | "red" | "yellow" | "blue" | "gray" }) {
+	const colors = {
+		green: "bg-green-900 text-green-300 border-green-700",
+		red: "bg-red-900 text-red-300 border-red-700",
+		yellow: "bg-yellow-900 text-yellow-300 border-yellow-700",
+		blue: "bg-blue-900 text-blue-300 border-blue-700",
+		gray: "bg-gray-800 text-gray-300 border-gray-600",
+	};
+	return (
+		<span
+			class={`inline-block px-2 py-0.5 text-xs font-medium rounded border ${colors[color]}`}
+		>
+			{label}
+		</span>
+	);
+}
+
+function EventLabel({
+	label,
+	color,
+}: { label: string; color: "green" | "red" | "yellow" | "blue" }) {
+	const colors = {
+		green: "text-green-400",
+		red: "text-red-400",
+		yellow: "text-yellow-400",
+		blue: "text-blue-400",
+	};
+	return (
+		<span class={`text-xs font-semibold uppercase ${colors[color]}`}>
+			{label}
+		</span>
+	);
+}
+
+function tryParseCommand(toolParameters: string | null): string | null {
+	if (!toolParameters) return null;
+	try {
+		const parsed = JSON.parse(toolParameters);
+		return typeof parsed.command === "string" ? parsed.command : null;
+	} catch {
+		return null;
+	}
+}
+
+function UserPromptCard(
+	event: Extract<TimelineEvent, { type: "user_prompt" }>,
+) {
+	return (
+		<div class="bg-gray-900 border border-gray-700 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<EventLabel label="User Prompt" color="blue" />
+				<span class="text-xs text-gray-500">
+					{formatTime(event.timestampMs)}
+				</span>
+			</div>
+			<p class="text-sm text-gray-300">{event.promptLength} characters</p>
+			{event.prompt && (
+				<details class="mt-2">
+					<summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-300">
+						Show prompt
+					</summary>
+					<pre class="mt-2 text-xs text-gray-300 bg-gray-800 rounded p-3 overflow-x-auto whitespace-pre-wrap break-words">
+						{event.prompt}
+					</pre>
+				</details>
+			)}
+		</div>
+	);
+}
+
+function ApiRequestCard(
+	event: Extract<TimelineEvent, { type: "api_request" }>,
+) {
+	return (
+		<div class="bg-gray-900 border border-gray-700 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<EventLabel label="API Request" color="green" />
+				<span class="text-xs text-gray-500">
+					{formatTime(event.timestampMs)}
+				</span>
+			</div>
+			<div class="flex flex-wrap gap-3 text-sm">
+				<span class="text-gray-300 font-mono text-xs">{event.model}</span>
+				<span class="text-gray-300">{formatCost(event.costUsd)}</span>
+				<span class="text-gray-300">{formatDurationMs(event.durationMs)}</span>
+			</div>
+			<div class="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
+				<span>In: {formatTokens(event.inputTokens)}</span>
+				<span>Out: {formatTokens(event.outputTokens)}</span>
+				{event.cacheReadTokens > 0 && (
+					<span>Cache read: {formatTokens(event.cacheReadTokens)}</span>
+				)}
+				{event.cacheCreationTokens > 0 && (
+					<span>Cache create: {formatTokens(event.cacheCreationTokens)}</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function ToolResultCard(
+	event: Extract<TimelineEvent, { type: "tool_result" }>,
+) {
+	const command =
+		event.toolName === "Bash" ? tryParseCommand(event.toolParameters) : null;
+
+	return (
+		<div class="bg-gray-900 border border-gray-700 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<EventLabel
+					label="Tool Result"
+					color={event.success ? "green" : "red"}
+				/>
+				<span class="text-xs text-gray-500">
+					{formatTime(event.timestampMs)}
+				</span>
+			</div>
+			<div class="flex items-center gap-3 text-sm">
+				<span class="text-gray-300 font-mono text-xs">{event.toolName}</span>
+				<Badge
+					label={event.success ? "success" : "failed"}
+					color={event.success ? "green" : "red"}
+				/>
+				<span class="text-gray-400 text-xs">
+					{formatDurationMs(event.durationMs)}
+				</span>
+			</div>
+			{command && (
+				<pre class="mt-2 text-xs text-gray-300 bg-gray-800 rounded p-3 overflow-x-auto whitespace-pre-wrap break-words">
+					$ {command}
+				</pre>
+			)}
+			{event.error && (
+				<p class="mt-2 text-xs text-red-400 bg-red-900/30 rounded p-2">
+					{event.error}
+				</p>
+			)}
+		</div>
+	);
+}
+
+function ToolDecisionCard(
+	event: Extract<TimelineEvent, { type: "tool_decision" }>,
+) {
+	const isAccept = event.decision === "accept";
+	return (
+		<div class="bg-gray-900 border border-gray-700 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<EventLabel label="Tool Decision" color="yellow" />
+				<span class="text-xs text-gray-500">
+					{formatTime(event.timestampMs)}
+				</span>
+			</div>
+			<div class="flex items-center gap-3 text-sm">
+				<span class="text-gray-300 font-mono text-xs">{event.toolName}</span>
+				<Badge label={event.decision} color={isAccept ? "green" : "red"} />
+				{event.source && (
+					<span class="text-gray-400 text-xs">{event.source}</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function ApiErrorCard(event: Extract<TimelineEvent, { type: "api_error" }>) {
+	return (
+		<div class="bg-gray-900 border border-red-800 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<EventLabel label="API Error" color="red" />
+				<span class="text-xs text-gray-500">
+					{formatTime(event.timestampMs)}
+				</span>
+			</div>
+			<div class="flex flex-wrap items-center gap-3 text-sm">
+				{event.model && (
+					<span class="text-gray-300 font-mono text-xs">{event.model}</span>
+				)}
+				{event.statusCode && (
+					<Badge label={String(event.statusCode)} color="red" />
+				)}
+				<span class="text-gray-400 text-xs">
+					{formatDurationMs(event.durationMs)}
+				</span>
+				<span class="text-gray-400 text-xs">attempt #{event.attempt}</span>
+			</div>
+			<p class="mt-2 text-xs text-red-400 bg-red-900/30 rounded p-2">
+				{event.error}
+			</p>
+		</div>
+	);
+}
+
+function EventCard({ event }: { event: TimelineEvent }) {
+	switch (event.type) {
+		case "user_prompt":
+			return <UserPromptCard {...event} />;
+		case "api_request":
+			return <ApiRequestCard {...event} />;
+		case "tool_result":
+			return <ToolResultCard {...event} />;
+		case "tool_decision":
+			return <ToolDecisionCard {...event} />;
+		case "api_error":
+			return <ApiErrorCard {...event} />;
+	}
+}
+
+export function SessionTimeline({
+	session,
+	events,
+}: { session: SessionInfo; events: TimelineEvent[] }) {
+	return (
+		<section>
+			<div class="mb-6">
+				<div class="flex items-center gap-3 mb-2">
+					<a href="/" class="text-sm text-blue-400 hover:text-blue-300">
+						Dashboard
+					</a>
+					<span class="text-gray-600">/</span>
+					<span class="text-sm text-gray-400">Session</span>
+				</div>
+				<h2 class="text-lg font-semibold mb-1">Session Detail</h2>
+				<div class="flex flex-wrap gap-4 text-sm text-gray-400">
+					<span class="font-mono text-xs">{session.sessionId}</span>
+					{session.repository && <span>{session.repository}</span>}
+					<span>
+						{formatDuration(session.firstEventAt, session.lastEventAt)}
+					</span>
+					<span>{formatTime(session.firstEventAt)}</span>
+				</div>
+			</div>
+
+			{events.length === 0 ? (
+				<p class="text-gray-400 text-sm">No events found.</p>
+			) : (
+				<div class="flex flex-col gap-3">
+					<p class="text-sm text-gray-500">{events.length} events</p>
+					{events.map((event) => (
+						<EventCard
+							key={`${event.type}-${event.eventSequence ?? event.timestampMs}`}
+							event={event}
+						/>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatCost,
+	formatDuration,
+	formatDurationMs,
+	formatTime,
+	formatTokens,
+} from "./format";
+
+describe("formatCost", () => {
+	it("小数第4位まで表示する", () => {
+		expect(formatCost(0.0123)).toBe("$0.0123");
+	});
+
+	it("0の場合", () => {
+		expect(formatCost(0)).toBe("$0.0000");
+	});
+
+	it("大きな値も正しくフォーマットする", () => {
+		expect(formatCost(1.5)).toBe("$1.5000");
+	});
+});
+
+describe("formatTokens", () => {
+	it("100万以上は M 表記", () => {
+		expect(formatTokens(1_500_000)).toBe("1.5M");
+	});
+
+	it("1000以上は K 表記", () => {
+		expect(formatTokens(1500)).toBe("1.5K");
+	});
+
+	it("1000未満はそのまま", () => {
+		expect(formatTokens(999)).toBe("999");
+	});
+
+	it("0の場合", () => {
+		expect(formatTokens(0)).toBe("0");
+	});
+});
+
+describe("formatTime", () => {
+	it("ISO形式の日時を空白区切りで表示する", () => {
+		const ms = new Date("2025-01-15T12:00:00Z").getTime();
+		expect(formatTime(ms)).toBe("2025-01-15 12:00:00");
+	});
+});
+
+describe("formatDuration", () => {
+	it("60秒未満は秒表示", () => {
+		const first = 1000;
+		const last = 31000;
+		expect(formatDuration(first, last)).toBe("30s");
+	});
+
+	it("60秒以上は分表示", () => {
+		const first = 0;
+		const last = 120_000;
+		expect(formatDuration(first, last)).toBe("2m");
+	});
+
+	it("60分以上は時間表示", () => {
+		const first = 0;
+		const last = 3_600_000;
+		expect(formatDuration(first, last)).toBe("1.0h");
+	});
+});
+
+describe("formatDurationMs", () => {
+	it("1000ms以上は秒表示", () => {
+		expect(formatDurationMs(1500)).toBe("1.5s");
+	});
+
+	it("1000ms未満はms表示", () => {
+		expect(formatDurationMs(150)).toBe("150ms");
+	});
+
+	it("0の場合", () => {
+		expect(formatDurationMs(0)).toBe("0ms");
+	});
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,26 @@
+export function formatCost(usd: number): string {
+	return `$${usd.toFixed(4)}`;
+}
+
+export function formatTokens(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}
+
+export function formatTime(ms: number): string {
+	const d = new Date(ms);
+	return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+export function formatDuration(firstMs: number, lastMs: number): string {
+	const diff = lastMs - firstMs;
+	if (diff < 60_000) return `${Math.round(diff / 1000)}s`;
+	if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m`;
+	return `${(diff / 3_600_000).toFixed(1)}h`;
+}
+
+export function formatDurationMs(ms: number): string {
+	if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+	return `${Math.round(ms)}ms`;
+}

--- a/src/queries/session.test.ts
+++ b/src/queries/session.test.ts
@@ -1,0 +1,248 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import {
+	insertApiErrors,
+	insertApiRequests,
+	insertToolDecisions,
+	insertToolResults,
+	insertUserPrompts,
+	upsertSessions,
+} from "../repositories/events";
+import type {
+	ParsedApiError,
+	ParsedApiRequest,
+	ParsedToolDecision,
+	ParsedToolResult,
+	ParsedUserPrompt,
+} from "../types/domain";
+import { getSessionInfo, getSessionTimeline } from "./session";
+
+const now = Date.now();
+
+function makeApiRequest(
+	overrides?: Partial<ParsedApiRequest>,
+): ParsedApiRequest {
+	return {
+		sessionId: "sess-timeline",
+		eventSequence: 1,
+		timestampNs: "1700000000000000000",
+		timestampMs: now,
+		model: "claude-sonnet-4-5-20250929",
+		costUsd: 0.01,
+		durationMs: 1500,
+		inputTokens: 100,
+		outputTokens: 50,
+		cacheReadTokens: 10,
+		cacheCreationTokens: 5,
+		...overrides,
+	};
+}
+
+function makeToolResult(
+	overrides?: Partial<ParsedToolResult>,
+): ParsedToolResult {
+	return {
+		sessionId: "sess-timeline",
+		eventSequence: 2,
+		timestampNs: "1700000001000000000",
+		timestampMs: now + 1000,
+		toolName: "Read",
+		success: true,
+		durationMs: 100,
+		error: null,
+		decision: null,
+		source: null,
+		toolParameters: null,
+		...overrides,
+	};
+}
+
+function makeUserPrompt(
+	overrides?: Partial<ParsedUserPrompt>,
+): ParsedUserPrompt {
+	return {
+		sessionId: "sess-timeline",
+		eventSequence: 3,
+		timestampNs: "1700000002000000000",
+		timestampMs: now + 2000,
+		promptLength: 42,
+		prompt: "Hello world",
+		...overrides,
+	};
+}
+
+function makeToolDecision(
+	overrides?: Partial<ParsedToolDecision>,
+): ParsedToolDecision {
+	return {
+		sessionId: "sess-timeline",
+		eventSequence: 4,
+		timestampNs: "1700000003000000000",
+		timestampMs: now + 3000,
+		toolName: "Bash",
+		decision: "accept",
+		source: "user",
+		...overrides,
+	};
+}
+
+function makeApiError(overrides?: Partial<ParsedApiError>): ParsedApiError {
+	return {
+		sessionId: "sess-timeline",
+		eventSequence: 5,
+		timestampNs: "1700000004000000000",
+		timestampMs: now + 4000,
+		model: "claude-sonnet-4-5-20250929",
+		error: "Rate limit exceeded",
+		statusCode: 429,
+		durationMs: 100,
+		attempt: 1,
+		...overrides,
+	};
+}
+
+describe("getSessionInfo", () => {
+	it("存在する sessionId の情報を返す", async () => {
+		await upsertSessions(env.DB, [
+			{
+				sessionId: "sess-info-1",
+				repository: "owner/repo",
+				timestampMs: now,
+			},
+		]);
+
+		const info = await getSessionInfo(env.DB, "sess-info-1");
+		expect(info).not.toBeNull();
+		expect(info?.sessionId).toBe("sess-info-1");
+		expect(info?.repository).toBe("owner/repo");
+		expect(typeof info?.firstEventAt).toBe("number");
+		expect(typeof info?.lastEventAt).toBe("number");
+	});
+
+	it("存在しない sessionId は null を返す", async () => {
+		const info = await getSessionInfo(env.DB, "nonexistent-session");
+		expect(info).toBeNull();
+	});
+});
+
+describe("getSessionTimeline", () => {
+	it("5テーブルすべてのイベントを event_sequence → timestamp_ms 順で返す", async () => {
+		const sid = "sess-all-events";
+		await Promise.all([
+			insertApiRequests(env.DB, [
+				makeApiRequest({ sessionId: sid, eventSequence: 1, timestampMs: now }),
+			]),
+			insertToolResults(env.DB, [
+				makeToolResult({
+					sessionId: sid,
+					eventSequence: 2,
+					timestampMs: now + 1000,
+				}),
+			]),
+			insertUserPrompts(env.DB, [
+				makeUserPrompt({
+					sessionId: sid,
+					eventSequence: 3,
+					timestampMs: now + 2000,
+				}),
+			]),
+			insertToolDecisions(env.DB, [
+				makeToolDecision({
+					sessionId: sid,
+					eventSequence: 4,
+					timestampMs: now + 3000,
+				}),
+			]),
+			insertApiErrors(env.DB, [
+				makeApiError({
+					sessionId: sid,
+					eventSequence: 5,
+					timestampMs: now + 4000,
+				}),
+			]),
+		]);
+
+		const events = await getSessionTimeline(env.DB, sid);
+		expect(events.length).toBe(5);
+
+		// event_sequence 順
+		const types = events.map((e) => e.type);
+		expect(types).toEqual([
+			"api_request",
+			"tool_result",
+			"user_prompt",
+			"tool_decision",
+			"api_error",
+		]);
+	});
+
+	it("event_sequence が null のイベントは非 null の後に配置される", async () => {
+		const sid = "sess-null-seq";
+		await Promise.all([
+			insertApiRequests(env.DB, [
+				makeApiRequest({
+					sessionId: sid,
+					eventSequence: 1,
+					timestampMs: now,
+				}),
+			]),
+			insertToolResults(env.DB, [
+				makeToolResult({
+					sessionId: sid,
+					eventSequence: null,
+					timestampMs: now + 500,
+				}),
+			]),
+		]);
+
+		const events = await getSessionTimeline(env.DB, sid);
+		expect(events.length).toBe(2);
+		expect(events[0].type).toBe("api_request");
+		expect(events[0].eventSequence).toBe(1);
+		expect(events[1].type).toBe("tool_result");
+		expect(events[1].eventSequence).toBeNull();
+	});
+
+	it("1テーブルのみにイベントがある場合そのイベントのみ返す", async () => {
+		const sid = "sess-single-table";
+		await insertUserPrompts(env.DB, [
+			makeUserPrompt({ sessionId: sid, eventSequence: 1 }),
+		]);
+
+		const events = await getSessionTimeline(env.DB, sid);
+		expect(events.length).toBe(1);
+		expect(events[0].type).toBe("user_prompt");
+	});
+
+	it("イベントが0件の場合空配列を返す", async () => {
+		const events = await getSessionTimeline(env.DB, "sess-no-events-at-all");
+		expect(events).toEqual([]);
+	});
+
+	it("tool_result の success = 1 が boolean true に変換される", async () => {
+		const sid = "sess-bool-check";
+		await insertToolResults(env.DB, [
+			makeToolResult({
+				sessionId: sid,
+				success: true,
+				eventSequence: 1,
+			}),
+			makeToolResult({
+				sessionId: sid,
+				success: false,
+				eventSequence: 2,
+				timestampMs: now + 1000,
+			}),
+		]);
+
+		const events = await getSessionTimeline(env.DB, sid);
+		const toolEvents = events.filter((e) => e.type === "tool_result");
+		expect(toolEvents.length).toBe(2);
+		if (toolEvents[0].type === "tool_result") {
+			expect(toolEvents[0].success).toBe(true);
+		}
+		if (toolEvents[1].type === "tool_result") {
+			expect(toolEvents[1].success).toBe(false);
+		}
+	});
+});

--- a/src/queries/session.ts
+++ b/src/queries/session.ts
@@ -1,0 +1,184 @@
+export type SessionInfo = {
+	sessionId: string;
+	repository: string | null;
+	firstEventAt: number;
+	lastEventAt: number;
+};
+
+export type TimelineEvent =
+	| {
+			type: "user_prompt";
+			eventSequence: number | null;
+			timestampMs: number;
+			promptLength: number;
+			prompt: string | null;
+	  }
+	| {
+			type: "api_request";
+			eventSequence: number | null;
+			timestampMs: number;
+			model: string;
+			costUsd: number;
+			durationMs: number;
+			inputTokens: number;
+			outputTokens: number;
+			cacheReadTokens: number;
+			cacheCreationTokens: number;
+	  }
+	| {
+			type: "tool_result";
+			eventSequence: number | null;
+			timestampMs: number;
+			toolName: string;
+			success: boolean;
+			durationMs: number;
+			error: string | null;
+			toolParameters: string | null;
+	  }
+	| {
+			type: "tool_decision";
+			eventSequence: number | null;
+			timestampMs: number;
+			toolName: string;
+			decision: string;
+			source: string | null;
+	  }
+	| {
+			type: "api_error";
+			eventSequence: number | null;
+			timestampMs: number;
+			model: string | null;
+			error: string;
+			statusCode: number | null;
+			durationMs: number;
+			attempt: number;
+	  };
+
+export async function getSessionInfo(
+	db: D1Database,
+	sessionId: string,
+): Promise<SessionInfo | null> {
+	const result = await db
+		.prepare(
+			"SELECT session_id, repository, first_event_at, last_event_at FROM sessions WHERE session_id = ?",
+		)
+		.bind(sessionId)
+		.first();
+
+	if (!result) return null;
+
+	return {
+		sessionId: result.session_id as string,
+		repository: result.repository as string | null,
+		firstEventAt: result.first_event_at as number,
+		lastEventAt: result.last_event_at as number,
+	};
+}
+
+export async function getSessionTimeline(
+	db: D1Database,
+	sessionId: string,
+): Promise<TimelineEvent[]> {
+	const [apiRequests, toolResults, userPrompts, toolDecisions, apiErrors] =
+		await Promise.all([
+			db
+				.prepare(
+					"SELECT event_sequence, timestamp_ms, model, cost_usd, duration_ms, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens FROM api_requests WHERE session_id = ?",
+				)
+				.bind(sessionId)
+				.all(),
+			db
+				.prepare(
+					"SELECT event_sequence, timestamp_ms, tool_name, success, duration_ms, error, tool_parameters FROM tool_results WHERE session_id = ?",
+				)
+				.bind(sessionId)
+				.all(),
+			db
+				.prepare(
+					"SELECT event_sequence, timestamp_ms, prompt_length, prompt FROM user_prompts WHERE session_id = ?",
+				)
+				.bind(sessionId)
+				.all(),
+			db
+				.prepare(
+					"SELECT event_sequence, timestamp_ms, tool_name, decision, source FROM tool_decisions WHERE session_id = ?",
+				)
+				.bind(sessionId)
+				.all(),
+			db
+				.prepare(
+					"SELECT event_sequence, timestamp_ms, model, error, status_code, duration_ms, attempt FROM api_errors WHERE session_id = ?",
+				)
+				.bind(sessionId)
+				.all(),
+		]);
+
+	const events: TimelineEvent[] = [
+		...apiRequests.results.map(
+			(r): TimelineEvent => ({
+				type: "api_request",
+				eventSequence: r.event_sequence as number | null,
+				timestampMs: r.timestamp_ms as number,
+				model: r.model as string,
+				costUsd: r.cost_usd as number,
+				durationMs: r.duration_ms as number,
+				inputTokens: r.input_tokens as number,
+				outputTokens: r.output_tokens as number,
+				cacheReadTokens: r.cache_read_tokens as number,
+				cacheCreationTokens: r.cache_creation_tokens as number,
+			}),
+		),
+		...toolResults.results.map(
+			(r): TimelineEvent => ({
+				type: "tool_result",
+				eventSequence: r.event_sequence as number | null,
+				timestampMs: r.timestamp_ms as number,
+				toolName: r.tool_name as string,
+				success: (r.success as number) === 1,
+				durationMs: r.duration_ms as number,
+				error: r.error as string | null,
+				toolParameters: r.tool_parameters as string | null,
+			}),
+		),
+		...userPrompts.results.map(
+			(r): TimelineEvent => ({
+				type: "user_prompt",
+				eventSequence: r.event_sequence as number | null,
+				timestampMs: r.timestamp_ms as number,
+				promptLength: r.prompt_length as number,
+				prompt: r.prompt as string | null,
+			}),
+		),
+		...toolDecisions.results.map(
+			(r): TimelineEvent => ({
+				type: "tool_decision",
+				eventSequence: r.event_sequence as number | null,
+				timestampMs: r.timestamp_ms as number,
+				toolName: r.tool_name as string,
+				decision: r.decision as string,
+				source: r.source as string | null,
+			}),
+		),
+		...apiErrors.results.map(
+			(r): TimelineEvent => ({
+				type: "api_error",
+				eventSequence: r.event_sequence as number | null,
+				timestampMs: r.timestamp_ms as number,
+				model: r.model as string | null,
+				error: r.error as string,
+				statusCode: r.status_code as number | null,
+				durationMs: r.duration_ms as number,
+				attempt: r.attempt as number,
+			}),
+		),
+	];
+
+	events.sort((a, b) => {
+		const seqA = a.eventSequence ?? Number.MAX_SAFE_INTEGER;
+		const seqB = b.eventSequence ?? Number.MAX_SAFE_INTEGER;
+		if (seqA !== seqB) return seqA - seqB;
+		return a.timestampMs - b.timestampMs;
+	});
+
+	return events;
+}

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -4,6 +4,7 @@ import { DailyTokens } from "../components/DailyTokens";
 import { Layout } from "../components/Layout";
 import { Overview } from "../components/Overview";
 import { RecentSessions } from "../components/RecentSessions";
+import { SessionTimeline } from "../components/SessionTimeline";
 import { ToolUsage } from "../components/ToolUsage";
 import {
 	getDailyCosts,
@@ -12,6 +13,7 @@ import {
 	getRecentSessions,
 	getToolUsage,
 } from "../queries/dashboard";
+import { getSessionInfo, getSessionTimeline } from "../queries/session";
 import type { Bindings } from "../types/env";
 
 const dashboard = new Hono<{ Bindings: Bindings }>();
@@ -33,6 +35,40 @@ dashboard.get("/", async (c) => {
 			<DailyCosts rows={dailyCosts} />
 			<ToolUsage tools={toolUsage} />
 			<RecentSessions sessions={sessions} />
+		</Layout>,
+	);
+});
+
+dashboard.get("/session/:id", async (c) => {
+	const sessionId = c.req.param("id");
+	const session = await getSessionInfo(c.env.DB, sessionId);
+
+	if (!session) {
+		return c.html(
+			<Layout>
+				<section>
+					<div class="flex items-center gap-3 mb-4">
+						<a href="/" class="text-sm text-blue-400 hover:text-blue-300">
+							Dashboard
+						</a>
+						<span class="text-gray-600">/</span>
+						<span class="text-sm text-gray-400">Session</span>
+					</div>
+					<h2 class="text-lg font-semibold mb-2">Session Not Found</h2>
+					<p class="text-gray-400 text-sm">
+						Session <code class="font-mono">{sessionId}</code> does not exist.
+					</p>
+				</section>
+			</Layout>,
+			404,
+		);
+	}
+
+	const events = await getSessionTimeline(c.env.DB, sessionId);
+
+	return c.html(
+		<Layout>
+			<SessionTimeline session={session} events={events} />
 		</Layout>,
 	);
 });


### PR DESCRIPTION
## Summary

- format ヘルパー（`formatCost`, `formatTokens`, `formatTime`, `formatDuration`, `formatDurationMs`）を `src/lib/format.ts` に共通化し、`Overview.tsx` / `RecentSessions.tsx` / `DailyCosts.tsx` の重複を除去
- セッションクエリ層（`getSessionInfo`, `getSessionTimeline`）を追加。5テーブル並列クエリ → `event_sequence` / `timestamp_ms` でマージソート
- タイムラインコンポーネント（`SessionTimeline.tsx`）を追加。イベント種別ごとのカード表示（user_prompt, api_request, tool_result, tool_decision, api_error）
- `GET /session/:id` ルートを追加（存在しないセッションは 404 HTML を返す）
- `RecentSessions` のセッション ID を `/session/{id}` へのリンクに変更

Closes #7

## Test plan

- [x] `pnpm test` — 110 tests passed（format 14 + session queries 7 + 既存 89）
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint` — エラーなし
- [ ] `GET /session/{valid-id}` → 200 + タイムライン HTML
- [ ] `GET /session/nonexistent` → 404 + エラーページ HTML
- [ ] RecentSessions のセッション ID クリックでセッション詳細ページに遷移
- [ ] タイムラインのカード表示（各イベント種別の表示確認）
- [ ] ダッシュボードへの戻りリンクが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)