### PR TITLE
リポジトリ別コスト集計・フィルタ機能を追加

### DIFF
--- a/docs/plan/v0.7.0.md
+++ b/docs/plan/v0.7.0.md
@@ -1,0 +1,59 @@
+# v0.7.0: リポジトリ別コスト集計・フィルタ (Issue #8)
+
+## Context
+
+ダッシュボードに**リポジトリ（プロジェクト）別のコスト集計とフィルタリング機能**を追加する。
+現在は全セッションを一括表示しているが、Claude Code を複数プロジェクトで使う場合にリポジトリ別のコスト把握ができない。
+
+`sessions.repository` カラム・インデックスおよびOTLP取込処理は Issue #6 で完了済み。
+本タスクはUI・クエリ層の対応。
+
+## 設計判断
+
+| 判断 | 選択 | 理由 |
+|------|------|------|
+| フィルタのURLパラメータ名 | `repo` | 短く可読性が高い。GitHub慣習と一致 |
+| repository IS NULL の表現 | URL: `?repo=__uncategorized__`, 表示: 「未分類」 | sentinel値で明確に区別 |
+| フィルタ時のJOIN戦略 | `repo` パラメータなし→JOINなし（現行動作維持）、あり→`JOIN sessions` | 未フィルタ時のパフォーマンス劣化を防止 |
+| RecentSessions の repository 取得 | 常に `LEFT JOIN sessions` | フィルタ有無に関わらず列表示が必要 |
+| RepositoryCosts のフィルタ | 常に全リポジトリ表示（フィルタ対象外） | 比較コンテキストとして全体俯瞰を維持 |
+
+## 内部型の設計
+
+```typescript
+// フィルタの3状態を表現
+// undefined → フィルタなし（全データ）
+// string   → WHERE s.repository = ?
+// null     → WHERE s.repository IS NULL（未分類）
+type RepoFilter = string | null | undefined;
+```
+
+URL パラメータからの変換:
+- `?repo` なし → `undefined`
+- `?repo=cc-dashboard` → `"cc-dashboard"`
+- `?repo=__uncategorized__` → `null`
+
+## タスク
+
+### タスク 1: 既存クエリに repository フィルタを追加
+
+**変更対象**: `src/queries/dashboard.ts`, `src/queries/dashboard.test.ts`
+
+全5関数に `repo?: RepoFilter` パラメータ追加。`buildRepoJoin` ヘルパーで SQL 構築を共通化。
+SessionRow に `repository: string | null` フィールド追加。
+
+### タスク 2: リポジトリ別コスト集計クエリ + リポジトリ一覧クエリを追加
+
+**変更対象**: `src/queries/dashboard.ts`, `src/queries/dashboard.test.ts`
+
+`getRepositoryCosts(db)` と `getDistinctRepositories(db)` の2つの新規クエリ関数を追加。
+
+### タスク 3: RepositoryFilter / RepositoryCosts コンポーネント作成
+
+**変更対象**: `src/components/RepositoryFilter.tsx`, `src/components/RepositoryCosts.tsx`, `src/components/charts/RepositoryCostChart.tsx`
+
+### タスク 4: ルート統合 + RecentSessions 更新
+
+**変更対象**: `src/routes/dashboard.tsx`, `src/components/RecentSessions.tsx`
+
+ルートで `repo` パラメータをパースし全クエリにフィルタを渡す。RecentSessions に Repository 列追加。

--- a/src/components/RecentSessions.tsx
+++ b/src/components/RecentSessions.tsx
@@ -24,6 +24,7 @@ export function RecentSessions({ sessions }: { sessions: SessionRow[] }) {
 					<thead>
 						<tr class="bg-gray-800 border-b border-gray-700">
 							<th class="text-left px-4 py-2 font-medium">Session ID</th>
+							<th class="text-left px-4 py-2 font-medium">Repository</th>
 							<th class="text-right px-4 py-2 font-medium">Cost</th>
 							<th class="text-right px-4 py-2 font-medium">Tokens</th>
 							<th class="text-right px-4 py-2 font-medium">API Calls</th>
@@ -43,13 +44,22 @@ export function RecentSessions({ sessions }: { sessions: SessionRow[] }) {
 										{s.sessionId}
 									</a>
 								</td>
-								<td class="px-4 py-2 text-right">{formatCost(s.totalCost)}</td>
-								<td class="px-4 py-2 text-right">
+								<td class="px-4 py-2 text-xs max-w-[150px] truncate">
+									{s.repository ? (
+										s.repository
+									) : (
+										<span class="text-gray-500">未分類</span>
+									)}
+								</td>
+								<td class="px-4 py-2 text-right tabular-nums">
+									{formatCost(s.totalCost)}
+								</td>
+								<td class="px-4 py-2 text-right tabular-nums">
 									{formatTokens(s.totalTokens)}
 								</td>
-								<td class="px-4 py-2 text-right">{s.apiCalls}</td>
-								<td class="px-4 py-2 text-right">{s.toolCalls}</td>
-								<td class="px-4 py-2 text-right">
+								<td class="px-4 py-2 text-right tabular-nums">{s.apiCalls}</td>
+								<td class="px-4 py-2 text-right tabular-nums">{s.toolCalls}</td>
+								<td class="px-4 py-2 text-right tabular-nums">
 									{formatDuration(s.firstSeen, s.lastSeen)}
 								</td>
 								<td class="px-4 py-2 text-right text-xs text-gray-400">

--- a/src/components/RepositoryCosts.tsx
+++ b/src/components/RepositoryCosts.tsx
@@ -1,0 +1,55 @@
+import { formatCost } from "../lib/format";
+import type { RepositoryCostRow } from "../queries/dashboard";
+import { RepositoryCostChart } from "./charts/RepositoryCostChart";
+
+export function RepositoryCosts({ rows }: { rows: RepositoryCostRow[] }) {
+	if (rows.length === 0) {
+		return (
+			<section>
+				<h2 class="text-lg font-semibold mb-3">Cost by Repository</h2>
+				<p class="text-gray-400 text-sm">No repository cost data yet.</p>
+			</section>
+		);
+	}
+
+	return (
+		<section>
+			<h2 class="text-lg font-semibold mb-3">Cost by Repository</h2>
+			<RepositoryCostChart rows={rows} />
+			<div class="overflow-x-auto">
+				<table class="w-full bg-gray-900 border border-gray-700 rounded-lg text-sm">
+					<thead>
+						<tr class="bg-gray-800 border-b border-gray-700">
+							<th class="text-left px-4 py-2 font-medium">Repository</th>
+							<th class="text-right px-4 py-2 font-medium">Cost</th>
+							<th class="text-right px-4 py-2 font-medium">Sessions</th>
+							<th class="text-right px-4 py-2 font-medium">API Calls</th>
+						</tr>
+					</thead>
+					<tbody>
+						{rows.map((row) => (
+							<tr key={row.repository} class="border-b border-gray-800">
+								<td class="px-4 py-2">
+									{row.repository === "未分類" ? (
+										<span class="text-gray-500">{row.repository}</span>
+									) : (
+										row.repository
+									)}
+								</td>
+								<td class="px-4 py-2 text-right tabular-nums">
+									{formatCost(row.totalCost)}
+								</td>
+								<td class="px-4 py-2 text-right tabular-nums">
+									{row.sessionCount}
+								</td>
+								<td class="px-4 py-2 text-right tabular-nums">
+									{row.apiCallCount}
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</section>
+	);
+}

--- a/src/components/RepositoryFilter.tsx
+++ b/src/components/RepositoryFilter.tsx
@@ -1,0 +1,62 @@
+const UNCATEGORIZED_PARAM = "__uncategorized__";
+
+export function RepositoryFilter({
+	repositories,
+	currentRepo,
+	hasUncategorized,
+}: {
+	repositories: string[];
+	currentRepo: string | null | undefined;
+	hasUncategorized: boolean;
+}) {
+	// リポジトリリストが空かつ未分類もなければ非表示
+	if (repositories.length === 0 && !hasUncategorized) return null;
+
+	const isAll = currentRepo === undefined;
+
+	return (
+		<section class="mb-6">
+			<h2 class="text-lg font-semibold mb-3">Repository</h2>
+			<nav class="flex flex-wrap gap-2" aria-label="Repository filter">
+				<a
+					href="/"
+					aria-current={isAll ? "page" : undefined}
+					class={`px-3 py-1 rounded-full text-sm transition-colors ${
+						isAll
+							? "bg-blue-900 text-blue-300"
+							: "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-300"
+					}`}
+				>
+					All
+				</a>
+				{repositories.map((repo) => (
+					<a
+						key={repo}
+						href={`/?repo=${encodeURIComponent(repo)}`}
+						aria-current={currentRepo === repo ? "page" : undefined}
+						class={`px-3 py-1 rounded-full text-sm transition-colors ${
+							currentRepo === repo
+								? "bg-blue-900 text-blue-300"
+								: "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-300"
+						}`}
+					>
+						{repo}
+					</a>
+				))}
+				{hasUncategorized && (
+					<a
+						href={`/?repo=${UNCATEGORIZED_PARAM}`}
+						aria-current={currentRepo === null ? "page" : undefined}
+						class={`px-3 py-1 rounded-full text-sm transition-colors ${
+							currentRepo === null
+								? "bg-blue-900 text-blue-300"
+								: "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-300"
+						}`}
+					>
+						未分類
+					</a>
+				)}
+			</nav>
+		</section>
+	);
+}

--- a/src/components/charts/RepositoryCostChart.tsx
+++ b/src/components/charts/RepositoryCostChart.tsx
@@ -1,0 +1,77 @@
+import { formatCost } from "../../lib/format";
+import type { RepositoryCostRow } from "../../queries/dashboard";
+import { BAR_COLOR } from "./chart-utils";
+
+const WIDTH = 600;
+const ROW_HEIGHT = 30;
+const PADDING_TOP = 10;
+const PADDING_BOTTOM = 10;
+const LABEL_WIDTH = 160;
+const BAR_LEFT = 170;
+const BAR_MAX_WIDTH = 380;
+const VALUE_OFFSET = 10;
+
+export function RepositoryCostChart({
+	rows,
+}: { rows: RepositoryCostRow[] }): ReturnType<typeof Object> | null {
+	if (rows.length === 0) return null;
+
+	const sorted = rows.slice().sort((a, b) => b.totalCost - a.totalCost);
+	const maxCost = Math.max(...sorted.map((r) => r.totalCost));
+	const height = PADDING_TOP + sorted.length * ROW_HEIGHT + PADDING_BOTTOM;
+
+	return (
+		<div class="mb-4 overflow-x-auto">
+			<svg
+				viewBox={`0 0 ${WIDTH} ${height}`}
+				width="100%"
+				role="img"
+				aria-label="Repository Cost Chart"
+			>
+				{sorted.map((row, i) => {
+					const y = PADDING_TOP + i * ROW_HEIGHT;
+					const barW =
+						maxCost > 0 ? (row.totalCost / maxCost) * BAR_MAX_WIDTH : 0;
+					return (
+						<g key={row.repository}>
+							<text
+								x={LABEL_WIDTH}
+								y={y + ROW_HEIGHT / 2}
+								fill="#d1d5db"
+								font-size="11"
+								text-anchor="end"
+								dominant-baseline="middle"
+							>
+								{row.repository.length > 22
+									? `${row.repository.slice(0, 22)}…`
+									: row.repository}
+							</text>
+							<rect
+								x={BAR_LEFT}
+								y={y + 6}
+								width={Math.max(barW, 1)}
+								height={ROW_HEIGHT - 12}
+								fill={BAR_COLOR}
+								rx="3"
+							>
+								<title>
+									{row.repository}: {formatCost(row.totalCost)},{" "}
+									{row.sessionCount} sessions, {row.apiCallCount} API calls
+								</title>
+							</rect>
+							<text
+								x={BAR_LEFT + barW + VALUE_OFFSET}
+								y={y + ROW_HEIGHT / 2}
+								fill="#9ca3af"
+								font-size="11"
+								dominant-baseline="middle"
+							>
+								{formatCost(row.totalCost)}
+							</text>
+						</g>
+					);
+				})}
+			</svg>
+		</div>
+	);
+}

--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -1,3 +1,6 @@
+// フィルタの3状態: undefined=フィルタなし, string=リポジトリ指定, null=未分類(IS NULL)
+export type RepoFilter = string | null | undefined;
+
 export type OverviewStats = {
 	totalCost: number;
 	totalInputTokens: number;
@@ -34,6 +37,7 @@ export type ToolUsageRow = {
 
 export type SessionRow = {
 	sessionId: string;
+	repository: string | null;
 	totalCost: number;
 	totalTokens: number;
 	toolCalls: number;
@@ -42,22 +46,60 @@ export type SessionRow = {
 	lastSeen: number;
 };
 
-export async function getOverviewStats(db: D1Database): Promise<OverviewStats> {
+export type RepositoryCostRow = {
+	repository: string;
+	totalCost: number;
+	sessionCount: number;
+	apiCallCount: number;
+};
+
+export function buildRepoJoin(
+	repo: RepoFilter,
+	alias: string,
+): { join: string; where: string; binds: unknown[] } {
+	if (repo === undefined) return { join: "", where: "", binds: [] };
+	if (repo === null)
+		return {
+			join: `JOIN sessions s ON ${alias}.session_id = s.session_id`,
+			where: "AND s.repository IS NULL",
+			binds: [],
+		};
+	return {
+		join: `JOIN sessions s ON ${alias}.session_id = s.session_id`,
+		where: "AND s.repository = ?",
+		binds: [repo],
+	};
+}
+
+export async function getOverviewStats(
+	db: D1Database,
+	repo?: RepoFilter,
+): Promise<OverviewStats> {
+	const repoJoin = buildRepoJoin(repo, "a");
+
 	const [costResult, sessionResult, errorResult] = await db.batch([
-		db.prepare(`
-			SELECT
-				COALESCE(SUM(cost_usd), 0) as total_cost,
-				COALESCE(SUM(input_tokens), 0) as total_input_tokens,
-				COALESCE(SUM(output_tokens), 0) as total_output_tokens,
-				COALESCE(SUM(cache_read_tokens), 0) as total_cache_read_tokens,
-				COALESCE(SUM(cache_creation_tokens), 0) as total_cache_creation_tokens,
+		db
+			.prepare(
+				`SELECT
+				COALESCE(SUM(a.cost_usd), 0) as total_cost,
+				COALESCE(SUM(a.input_tokens), 0) as total_input_tokens,
+				COALESCE(SUM(a.output_tokens), 0) as total_output_tokens,
+				COALESCE(SUM(a.cache_read_tokens), 0) as total_cache_read_tokens,
+				COALESCE(SUM(a.cache_creation_tokens), 0) as total_cache_creation_tokens,
 				COUNT(*) as api_call_count
-			FROM api_requests
-		`),
-		db.prepare(`
-			SELECT COUNT(DISTINCT session_id) as session_count
-			FROM api_requests
-		`),
+			FROM api_requests a
+			${repoJoin.join}
+			WHERE 1=1 ${repoJoin.where}`,
+			)
+			.bind(...repoJoin.binds),
+		db
+			.prepare(
+				`SELECT COUNT(DISTINCT a.session_id) as session_count
+			FROM api_requests a
+			${repoJoin.join}
+			WHERE 1=1 ${repoJoin.where}`,
+			)
+			.bind(...repoJoin.binds),
 		db.prepare(`
 			SELECT COUNT(*) as error_count
 			FROM api_errors
@@ -83,91 +125,123 @@ export async function getOverviewStats(db: D1Database): Promise<OverviewStats> {
 export async function getDailyCosts(
 	db: D1Database,
 	days = 30,
+	repo?: RepoFilter,
 ): Promise<DailyCostRow[]> {
+	const repoJoin = buildRepoJoin(repo, "a");
+	const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
 	const result = await db
 		.prepare(
 			`SELECT
-				date(timestamp_ms / 1000, 'unixepoch') as date,
-				model,
-				SUM(cost_usd) as cost,
+				date(a.timestamp_ms / 1000, 'unixepoch') as date,
+				a.model,
+				SUM(a.cost_usd) as cost,
 				COUNT(*) as calls
-			FROM api_requests
-			WHERE timestamp_ms >= ?
-			GROUP BY date, model
+			FROM api_requests a
+			${repoJoin.join}
+			WHERE a.timestamp_ms >= ? ${repoJoin.where}
+			GROUP BY date, a.model
 			ORDER BY date DESC, cost DESC`,
 		)
-		.bind(Date.now() - days * 24 * 60 * 60 * 1000)
+		.bind(cutoff, ...repoJoin.binds)
 		.all();
 
-	return result.results.map((r) => ({
-		date: r.date as string,
-		model: r.model as string,
-		cost: r.cost as number,
-		calls: r.calls as number,
+	return result.results.map((row) => ({
+		date: row.date as string,
+		model: row.model as string,
+		cost: row.cost as number,
+		calls: row.calls as number,
 	}));
 }
 
 export async function getDailyTokens(
 	db: D1Database,
 	days = 30,
+	repo?: RepoFilter,
 ): Promise<DailyTokenRow[]> {
+	const repoJoin = buildRepoJoin(repo, "a");
+	const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
 	const result = await db
 		.prepare(
 			`SELECT
-				date(timestamp_ms / 1000, 'unixepoch') as date,
-				SUM(input_tokens) as input_tokens,
-				SUM(output_tokens) as output_tokens,
-				SUM(cache_read_tokens) as cache_read_tokens,
-				SUM(cache_creation_tokens) as cache_creation_tokens
-			FROM api_requests
-			WHERE timestamp_ms >= ?
+				date(a.timestamp_ms / 1000, 'unixepoch') as date,
+				SUM(a.input_tokens) as input_tokens,
+				SUM(a.output_tokens) as output_tokens,
+				SUM(a.cache_read_tokens) as cache_read_tokens,
+				SUM(a.cache_creation_tokens) as cache_creation_tokens
+			FROM api_requests a
+			${repoJoin.join}
+			WHERE a.timestamp_ms >= ? ${repoJoin.where}
 			GROUP BY date
 			ORDER BY date DESC`,
 		)
-		.bind(Date.now() - days * 24 * 60 * 60 * 1000)
+		.bind(cutoff, ...repoJoin.binds)
 		.all();
 
-	return result.results.map((r) => ({
-		date: r.date as string,
-		inputTokens: r.input_tokens as number,
-		outputTokens: r.output_tokens as number,
-		cacheReadTokens: r.cache_read_tokens as number,
-		cacheCreationTokens: r.cache_creation_tokens as number,
+	return result.results.map((row) => ({
+		date: row.date as string,
+		inputTokens: row.input_tokens as number,
+		outputTokens: row.output_tokens as number,
+		cacheReadTokens: row.cache_read_tokens as number,
+		cacheCreationTokens: row.cache_creation_tokens as number,
 	}));
 }
 
-export async function getToolUsage(db: D1Database): Promise<ToolUsageRow[]> {
+export async function getToolUsage(
+	db: D1Database,
+	repo?: RepoFilter,
+): Promise<ToolUsageRow[]> {
+	const repoJoin = buildRepoJoin(repo, "tr");
+
 	const result = await db
 		.prepare(
 			`SELECT
-				tool_name,
+				tr.tool_name,
 				COUNT(*) as call_count,
-				SUM(success) as success_count,
-				ROUND(AVG(success) * 100, 1) as success_rate,
-				ROUND(AVG(duration_ms), 0) as avg_duration_ms
-			FROM tool_results
-			GROUP BY tool_name
+				SUM(tr.success) as success_count,
+				ROUND(AVG(tr.success) * 100, 1) as success_rate,
+				ROUND(AVG(tr.duration_ms), 0) as avg_duration_ms
+			FROM tool_results tr
+			${repoJoin.join}
+			WHERE 1=1 ${repoJoin.where}
+			GROUP BY tr.tool_name
 			ORDER BY call_count DESC`,
 		)
+		.bind(...repoJoin.binds)
 		.all();
 
-	return result.results.map((r) => ({
-		toolName: r.tool_name as string,
-		callCount: r.call_count as number,
-		successCount: r.success_count as number,
-		successRate: r.success_rate as number,
-		avgDurationMs: r.avg_duration_ms as number,
+	return result.results.map((row) => ({
+		toolName: row.tool_name as string,
+		callCount: row.call_count as number,
+		successCount: row.success_count as number,
+		successRate: row.success_rate as number,
+		avgDurationMs: row.avg_duration_ms as number,
 	}));
 }
 
 export async function getRecentSessions(
 	db: D1Database,
 	limit = 20,
+	repo?: RepoFilter,
 ): Promise<SessionRow[]> {
+	// repo フィルタ有無に関わらず sessions を JOIN して repository を取得
+	const hasFilter = repo !== undefined;
+	const joinType = hasFilter ? "JOIN" : "LEFT JOIN";
+	const whereClause =
+		repo === null
+			? "AND s.repository IS NULL"
+			: repo !== undefined
+				? "AND s.repository = ?"
+				: "";
+	const filterBinds: unknown[] =
+		repo !== undefined && repo !== null ? [repo] : [];
+
 	const result = await db
 		.prepare(
 			`SELECT
 				a.session_id,
+				s.repository,
 				COALESCE(SUM(a.cost_usd), 0) as total_cost,
 				COALESCE(SUM(a.input_tokens + a.output_tokens + a.cache_read_tokens + a.cache_creation_tokens), 0) as total_tokens,
 				COALESCE(t.tool_calls, 0) as tool_calls,
@@ -175,25 +249,68 @@ export async function getRecentSessions(
 				MIN(a.timestamp_ms) as first_seen,
 				MAX(a.timestamp_ms) as last_seen
 			FROM api_requests a
+			${joinType} sessions s ON a.session_id = s.session_id
 			LEFT JOIN (
 				SELECT session_id, COUNT(*) as tool_calls
 				FROM tool_results
 				GROUP BY session_id
 			) t ON a.session_id = t.session_id
+			WHERE 1=1 ${whereClause}
 			GROUP BY a.session_id
 			ORDER BY last_seen DESC
 			LIMIT ?`,
 		)
-		.bind(limit)
+		.bind(...filterBinds, limit)
 		.all();
 
-	return result.results.map((r) => ({
-		sessionId: r.session_id as string,
-		totalCost: r.total_cost as number,
-		totalTokens: r.total_tokens as number,
-		toolCalls: r.tool_calls as number,
-		apiCalls: r.api_calls as number,
-		firstSeen: r.first_seen as number,
-		lastSeen: r.last_seen as number,
+	return result.results.map((row) => ({
+		sessionId: row.session_id as string,
+		repository: (row.repository as string | null) ?? null,
+		totalCost: row.total_cost as number,
+		totalTokens: row.total_tokens as number,
+		toolCalls: row.tool_calls as number,
+		apiCalls: row.api_calls as number,
+		firstSeen: row.first_seen as number,
+		lastSeen: row.last_seen as number,
 	}));
+}
+
+export async function getRepositoryCosts(
+	db: D1Database,
+): Promise<RepositoryCostRow[]> {
+	const result = await db
+		.prepare(
+			`SELECT
+				COALESCE(s.repository, '未分類') as repository,
+				SUM(a.cost_usd) as total_cost,
+				COUNT(DISTINCT a.session_id) as session_count,
+				COUNT(*) as api_call_count
+			FROM api_requests a
+			JOIN sessions s ON a.session_id = s.session_id
+			GROUP BY COALESCE(s.repository, '未分類')
+			ORDER BY total_cost DESC`,
+		)
+		.all();
+
+	return result.results.map((row) => ({
+		repository: row.repository as string,
+		totalCost: row.total_cost as number,
+		sessionCount: row.session_count as number,
+		apiCallCount: row.api_call_count as number,
+	}));
+}
+
+export async function getDistinctRepositories(
+	db: D1Database,
+): Promise<string[]> {
+	const result = await db
+		.prepare(
+			`SELECT DISTINCT repository
+			FROM sessions
+			WHERE repository IS NOT NULL
+			ORDER BY repository`,
+		)
+		.all();
+
+	return result.results.map((row) => row.repository as string);
 }


### PR DESCRIPTION
## Summary

- `RepoFilter` 型（3状態: `undefined`/`string`/`null`）と `buildRepoJoin` ヘルパーで既存5クエリにリポジトリフィルタを追加
- `getRepositoryCosts` / `getDistinctRepositories` クエリを新規追加
- `RepositoryFilter`（ピル型ナビゲーション）、`RepositoryCosts`（テーブル＋SVG棒グラフ）コンポーネントを作成
- `RecentSessions` に Repository 列を追加
- ダッシュボードルートで `?repo` パラメータをパースしフィルタを適用
- アクセシビリティ改善（`aria-current`, `aria-label`, `tabular-nums`）

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] `pnpm test` 127件パス（27件新規追加）
- [ ] `/?repo=<name>` でリポジトリフィルタが動作する
- [ ] `/?repo=__uncategorized__` で未分類フィルタが動作する
- [ ] `/`（パラメータなし）で全データ表示（後方互換）
- [ ] RepositoryFilter のハイライトが正しい
- [ ] RepositoryCosts のグラフ・テーブルが正しく表示される

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)