### PR TITLE
リポジトリ別フィルタの設定ドキュメントと OTEL 設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repository=cc-dashboard"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ AUTH_TOKEN=dummy
 }
 ```
 
+### リポジトリ別フィルタの設定
+
+ダッシュボードはリポジトリ別にコストやセッションをフィルタできる。Claude Code は `repository` 属性を自動送信しないため、プロジェクトごとに `OTEL_RESOURCE_ATTRIBUTES` で明示的に設定する必要がある。
+
+各プロジェクトの `.claude/settings.json` に追加:
+
+```json
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repository=<リポジトリ名>"
+  }
+}
+```
+
+- `repository` の値はダッシュボードのフィルタドロップダウンに表示される
+- 設定しない場合、セッションの `repository` は空になりフィルタで「(未設定)」として扱われる
+- グローバル設定（`~/.claude/settings.json`）ではなくプロジェクトごとの設定（`.claude/settings.json`）を使う
+
 ### デプロイ
 
 ```bash


### PR DESCRIPTION
## Summary
- README.md にリポジトリフィルタ設定セクションを追記（`OTEL_RESOURCE_ATTRIBUTES` の設定方法）
- `.claude/settings.json` で本プロジェクトの `repository=cc-dashboard` を設定

## Test plan
- [ ] README.md の記述内容が正確か確認
- [ ] `.claude/settings.json` の設定で Claude Code セッションに `repository` 属性が付与されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)