### PR TITLE
ドキュメントのみの変更時に CI ジョブをスキップする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'test/**'
+              - 'migrations/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+              - 'biome.json'
+              - 'vitest.config.ts'
+              - 'wrangler.toml'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +43,8 @@ jobs:
       - run: pnpm lint
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +57,8 @@ jobs:
       - run: pnpm typecheck
 
   test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `dorny/paths-filter` で変更ファイルを検出する `changes` ジョブを追加
- ソースコード（`src/`, `test/`, `migrations/`, 設定ファイル等）に変更がない場合、lint/typecheck/test ジョブをスキップ
- スキップ対象: `*.md`, `docs/**`, `LICENSE` 等のドキュメントのみの変更

Closes #15

## Test plan
- [ ] ソースコード変更を含む PR で lint/typecheck/test が実行されることを確認
- [ ] ドキュメントのみの PR でジョブがスキップされることを確認（この PR マージ後に検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)