### PR TITLE
repository が常に null になるバグを修正

### DIFF
--- a/src/parsers/otlp-logs.test.ts
+++ b/src/parsers/otlp-logs.test.ts
@@ -16,13 +16,7 @@ function makeLogPayload(
 		resourceLogs: [
 			{
 				resource: {
-					attributes: [
-						{
-							key: "session.id",
-							value: { stringValue: sessionId },
-						},
-						...extraResourceAttrs,
-					],
+					attributes: [...extraResourceAttrs],
 				},
 				scopeLogs: [
 					{
@@ -33,6 +27,10 @@ function makeLogPayload(
 									{
 										key: "event.name",
 										value: { stringValue: eventName },
+									},
+									{
+										key: "session.id",
+										value: { stringValue: sessionId },
 									},
 									...attrs,
 								],

--- a/src/parsers/otlp-logs.ts
+++ b/src/parsers/otlp-logs.ts
@@ -23,16 +23,19 @@ export function parseLogsPayload(
 
 	for (const rl of payload.resourceLogs ?? []) {
 		const resourceAttrs = rl.resource?.attributes ?? [];
-
-		const sessionId = getStringAttr(resourceAttrs, "session.id") || "unknown";
 		const repository = getStringAttr(resourceAttrs, "repository");
-		resourceContexts.push({ sessionId, repository });
 
 		for (const sl of rl.scopeLogs ?? []) {
 			for (const record of sl.logRecords ?? []) {
 				const event = parseLogRecord(record, resourceAttrs);
 				if (event) {
 					events.push(event);
+					if (event.type !== "unknown") {
+						resourceContexts.push({
+							sessionId: event.data.sessionId,
+							repository,
+						});
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Claude Code は `session.id` を log record attributes に、`repository` を resource attributes に送信する
- パーサーが resource レベルで `session.id` を取得しようとして `"unknown"` になり、実際の session ID との紐づけに失敗していた
- 各 log record の session ID と resource の `repository` を直接紐づけるように修正

## Test plan
- [x] `src/parsers/otlp-logs.test.ts` 全17テスト通過
- [x] `src/routes/otlp.test.ts` 全12テスト通過
- [x] 全127テスト通過
- [x] 本番デプロイ済み、`wrangler tail` で resource attributes に `repository` が含まれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)