### PR TITLE
テストデータを実際の OTLP ペイロード構造に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,19 @@ xh --ignore-stdin POST http://localhost:{port}/v1/metrics Authorization:"Bearer 
 ### ダッシュボード目視確認（chrome-devtools MCP）
 
 chrome-devtools MCP でダッシュボードページを開き、フルページスクリーンショットを撮ってレイアウト崩れがないか確認する。
+
+## OTLP ペイロード構造
+
+Claude Code が送信する OTLP データは、`session.id` と `OTEL_RESOURCE_ATTRIBUTES` 由来の属性が**異なる階層**に配置される。
+
+```
+resourceLogs[]:
+  resource:
+    attributes: [repository, os.type, service.name, ...]  ← OTEL_RESOURCE_ATTRIBUTES 由来
+  scopeLogs[]:
+    logRecords[]:
+      attributes: [session.id, event.name, model, ...]    ← イベント固有
+```
+
+- `repository` は resource-level、`session.id` は record-level
+- パーサーで両者を紐づける際は、各 log record の session ID を使うこと（resource-level に session.id は存在しない）

--- a/src/parsers/otlp-logs.test.ts
+++ b/src/parsers/otlp-logs.test.ts
@@ -326,7 +326,12 @@ describe("parseLogsPayload", () => {
 				resourceLogs: [
 					{
 						resource: {
-							attributes: [{ key: "session.id", value: { stringValue: "s1" } }],
+							attributes: [
+								{
+									key: "repository",
+									value: { stringValue: "my-repo" },
+								},
+							],
 						},
 						scopeLogs: [
 							{
@@ -337,6 +342,10 @@ describe("parseLogsPayload", () => {
 											{
 												key: "event.name",
 												value: { stringValue: "api_request" },
+											},
+											{
+												key: "session.id",
+												value: { stringValue: "s1" },
 											},
 											{
 												key: "model",
@@ -350,6 +359,10 @@ describe("parseLogsPayload", () => {
 											{
 												key: "event.name",
 												value: { stringValue: "tool_result" },
+											},
+											{
+												key: "session.id",
+												value: { stringValue: "s1" },
 											},
 											{
 												key: "tool_name",
@@ -368,6 +381,9 @@ describe("parseLogsPayload", () => {
 			expect(result.events).toHaveLength(2);
 			expect(result.events[0].type).toBe("api_request");
 			expect(result.events[1].type).toBe("tool_result");
+			expect(result.resourceContexts).toHaveLength(2);
+			expect(result.resourceContexts[0].repository).toBe("my-repo");
+			expect(result.resourceContexts[0].sessionId).toBe("s1");
 		});
 	});
 });

--- a/src/parsers/otlp-metrics.test.ts
+++ b/src/parsers/otlp-metrics.test.ts
@@ -9,7 +9,14 @@ describe("parseMetricsPayload", () => {
 				{
 					resource: {
 						attributes: [
-							{ key: "session.id", value: { stringValue: "sess-001" } },
+							{
+								key: "repository",
+								value: { stringValue: "cc-dashboard" },
+							},
+							{
+								key: "service.name",
+								value: { stringValue: "claude-code" },
+							},
 						],
 					},
 					scopeMetrics: [
@@ -22,6 +29,10 @@ describe("parseMetricsPayload", () => {
 										dataPoints: [
 											{
 												attributes: [
+													{
+														key: "session.id",
+														value: { stringValue: "sess-001" },
+													},
 													{ key: "type", value: { stringValue: "input" } },
 													{
 														key: "model",
@@ -54,7 +65,7 @@ describe("parseMetricsPayload", () => {
 		expect(points[0].timestampMs).toBe(1700000000000);
 	});
 
-	it("Gauge メトリクスをパースする", () => {
+	it("active_time.total を Sum メトリクスとしてパースする", () => {
 		const payload: ExportMetricsServiceRequest = {
 			resourceMetrics: [
 				{
@@ -63,9 +74,22 @@ describe("parseMetricsPayload", () => {
 							metrics: [
 								{
 									name: "claude_code.active_time.total",
-									gauge: {
+									unit: "s",
+									sum: {
+										aggregationTemporality: 1,
+										isMonotonic: true,
 										dataPoints: [
 											{
+												attributes: [
+													{
+														key: "session.id",
+														value: { stringValue: "sess-001" },
+													},
+													{
+														key: "type",
+														value: { stringValue: "cli" },
+													},
+												],
 												timeUnixNano: "1700000000000000000",
 												asDouble: 120.5,
 											},
@@ -83,7 +107,8 @@ describe("parseMetricsPayload", () => {
 		expect(points).toHaveLength(1);
 		expect(points[0].metricName).toBe("claude_code.active_time.total");
 		expect(points[0].value).toBe(120.5);
-		expect(points[0].sessionId).toBeNull();
+		expect(points[0].sessionId).toBe("sess-001");
+		expect(points[0].attrType).toBe("cli");
 	});
 
 	it("複数メトリクス・複数 dataPoints をパースする", () => {

--- a/src/routes/otlp.test.ts
+++ b/src/routes/otlp.test.ts
@@ -28,17 +28,16 @@ describe("POST /v1/logs", () => {
 		const payload: ExportLogsServiceRequest = {
 			resourceLogs: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-test-s1" } },
-						],
-					},
 					scopeLogs: [
 						{
 							logRecords: [
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-test-s1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "api_request" },
@@ -127,17 +126,16 @@ describe("POST /v1/logs", () => {
 		const payload: ExportLogsServiceRequest = {
 			resourceLogs: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-up-1" } },
-						],
-					},
 					scopeLogs: [
 						{
 							logRecords: [
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-up-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "user_prompt" },
@@ -170,17 +168,16 @@ describe("POST /v1/logs", () => {
 		const payload: ExportLogsServiceRequest = {
 			resourceLogs: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-td-1" } },
-						],
-					},
 					scopeLogs: [
 						{
 							logRecords: [
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-td-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "tool_decision" },
@@ -215,17 +212,16 @@ describe("POST /v1/logs", () => {
 		const payload: ExportLogsServiceRequest = {
 			resourceLogs: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-tp-1" } },
-						],
-					},
 					scopeLogs: [
 						{
 							logRecords: [
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-tp-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "tool_result" },
@@ -262,7 +258,6 @@ describe("POST /v1/logs", () => {
 				{
 					resource: {
 						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-repo-1" } },
 							{ key: "repository", value: { stringValue: "cc-dashboard" } },
 						],
 					},
@@ -272,6 +267,10 @@ describe("POST /v1/logs", () => {
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-repo-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "api_request" },
@@ -307,17 +306,16 @@ describe("POST /v1/logs", () => {
 		const payload: ExportLogsServiceRequest = {
 			resourceLogs: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-session-1" } },
-						],
-					},
 					scopeLogs: [
 						{
 							logRecords: [
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-session-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "api_request" },
@@ -354,7 +352,6 @@ describe("POST /v1/logs", () => {
 				{
 					resource: {
 						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-mixed-1" } },
 							{ key: "repository", value: { stringValue: "test-repo" } },
 						],
 					},
@@ -364,6 +361,10 @@ describe("POST /v1/logs", () => {
 								{
 									timeUnixNano: "1700000000000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-mixed-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "api_request" },
@@ -378,6 +379,10 @@ describe("POST /v1/logs", () => {
 									timeUnixNano: "1700000001000000000",
 									attributes: [
 										{
+											key: "session.id",
+											value: { stringValue: "otlp-mixed-1" },
+										},
+										{
 											key: "event.name",
 											value: { stringValue: "tool_result" },
 										},
@@ -388,6 +393,10 @@ describe("POST /v1/logs", () => {
 									timeUnixNano: "1700000002000000000",
 									attributes: [
 										{
+											key: "session.id",
+											value: { stringValue: "otlp-mixed-1" },
+										},
+										{
 											key: "event.name",
 											value: { stringValue: "user_prompt" },
 										},
@@ -397,6 +406,10 @@ describe("POST /v1/logs", () => {
 								{
 									timeUnixNano: "1700000003000000000",
 									attributes: [
+										{
+											key: "session.id",
+											value: { stringValue: "otlp-mixed-1" },
+										},
 										{
 											key: "event.name",
 											value: { stringValue: "tool_decision" },
@@ -462,11 +475,6 @@ describe("POST /v1/metrics", () => {
 		const payload: ExportMetricsServiceRequest = {
 			resourceMetrics: [
 				{
-					resource: {
-						attributes: [
-							{ key: "session.id", value: { stringValue: "otlp-metric-s1" } },
-						],
-					},
 					scopeMetrics: [
 						{
 							metrics: [
@@ -478,6 +486,10 @@ describe("POST /v1/metrics", () => {
 												timeUnixNano: "1700000000000000000",
 												asInt: 500,
 												attributes: [
+													{
+														key: "session.id",
+														value: { stringValue: "otlp-metric-s1" },
+													},
 													{ key: "type", value: { stringValue: "input" } },
 												],
 											},

--- a/src/types/otlp.ts
+++ b/src/types/otlp.ts
@@ -17,6 +17,7 @@ export type KeyValue = {
 
 export type Resource = {
 	attributes?: KeyValue[];
+	droppedAttributesCount?: number;
 };
 
 // --- Logs ---
@@ -28,6 +29,7 @@ export type LogRecord = {
 	severityText?: string;
 	body?: AnyValue;
 	attributes?: KeyValue[];
+	droppedAttributesCount?: number;
 	traceId?: string;
 	spanId?: string;
 };


### PR DESCRIPTION
## Summary
- 全テストファイルで `session.id` の配置を実際の Claude Code OTLP ペイロード構造に合わせて修正（resource attributes → logRecord/dataPoint attributes）
- `active_time.total` メトリクスのテストを Gauge → Sum に変更（実データに合致）
- `Resource`/`LogRecord` 型に `droppedAttributesCount` フィールドを追加
- CLAUDE.md に OTLP ペイロード構造の説明を追加

## Test plan
- [x] 全 127 テスト通過
- [x] 型チェック通過
- [x] Biome lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)