### PR TITLE
ダッシュボードの時刻表示を JST (UTC+9) に対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Claude Code の OpenTelemetry データを受信・可視化する個人向け�
 - **ランタイム**: Cloudflare Workers
 - **DB**: Cloudflare D1
 - **フレームワーク**: Hono (JSX SSR)
-- **テスト**: Vitest + @cloudflare/vitest-pool-workers
+- **テスト**: Vitest + @cloudflare/vitest-pool-workers（テストファイルはソースと同階層に co-locate: `src/lib/format.test.ts`）
 - **lint/format**: Biome
 
 ## ローカル開発

--- a/docs/plan/v0.7.2.md
+++ b/docs/plan/v0.7.2.md
@@ -1,0 +1,57 @@
+# v0.7.2: ダッシュボードの時刻表示を JST (UTC+9) に対応する
+
+## Context
+
+Issue #18。現在すべての時刻表示が UTC 基準になっている。個人利用ダッシュボードなので JST 固定で表示したい。DB の `timestamp_ms` は UTC のまま維持し、表示層のみ変換する。
+
+## 変更対象
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/lib/format.ts` | `formatTime()` を JST 対応に変更 |
+| `src/lib/format.test.ts` | テストの期待値を JST に更新 |
+| `src/queries/dashboard.ts` | 日別集計 SQL に `'+9 hours'` 追加 |
+| `src/queries/dashboard.test.ts` | `msToDateStr` ヘルパーを JST 化 |
+
+## タスク
+
+### タスク 0: 計画ファイル保存 + 作業ブランチ作成
+
+**変更対象**: `docs/plan/v0.7.2.md`, git branch `fix/jst-timezone`
+
+### タスク 1: `formatTime()` を JST に変更
+
+**変更対象**: `src/lib/format.ts`, `src/lib/format.test.ts`
+
+**実装方針**: JST オフセット定数を定義し、`toISOString()` パターンを維持する。
+
+```typescript
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export function formatTime(ms: number): string {
+  const d = new Date(ms + JST_OFFSET_MS);
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+```
+
+**受入条件**:
+- WHEN `2025-01-15T12:00:00Z` を渡す THEN `"2025-01-15 21:00:00"` (JST) が返る
+- WHEN `2025-01-15T20:00:00Z` (JST 翌日 05:00) を渡す THEN `"2025-01-16 05:00:00"` が返る
+
+### タスク 2: 日別集計 SQL を JST に変更
+
+**変更対象**: `src/queries/dashboard.ts`, `src/queries/dashboard.test.ts`
+
+**実装方針**: SQLite の `date()` に `'+9 hours'` 修飾子を追加する。
+
+```sql
+date(a.timestamp_ms / 1000, 'unixepoch', '+9 hours') as date
+```
+
+対象箇所: `getDailyCosts()`, `getDailyTokens()` の 2 クエリ。
+
+テストの `msToDateStr` ヘルパーも同様に JST オフセットを加算する。
+
+**受入条件**:
+- WHEN JST で同一日のイベント THEN 同じ日付でグルーピングされる
+- WHEN UTC 15:00 (= JST 0:00) をまたぐイベント THEN JST 基準で異なる日付に分類される

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -40,9 +40,14 @@ describe("formatTokens", () => {
 });
 
 describe("formatTime", () => {
-	it("ISO形式の日時を空白区切りで表示する", () => {
+	it("UTC の時刻を JST (UTC+9) に変換して表示する", () => {
 		const ms = new Date("2025-01-15T12:00:00Z").getTime();
-		expect(formatTime(ms)).toBe("2025-01-15 12:00:00");
+		expect(formatTime(ms)).toBe("2025-01-15 21:00:00");
+	});
+
+	it("UTC 20:00 は JST で翌日 05:00 になる", () => {
+		const ms = new Date("2025-01-15T20:00:00Z").getTime();
+		expect(formatTime(ms)).toBe("2025-01-16 05:00:00");
 	});
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -8,8 +8,10 @@ export function formatTokens(n: number): string {
 	return String(n);
 }
 
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 export function formatTime(ms: number): string {
-	const d = new Date(ms);
+	const d = new Date(ms + JST_OFFSET_MS);
 	return d.toISOString().replace("T", " ").slice(0, 19);
 }
 

--- a/src/queries/dashboard.test.ts
+++ b/src/queries/dashboard.test.ts
@@ -80,9 +80,11 @@ function daysAgoMs(n: number): number {
 	return Date.now() - n * 24 * 60 * 60 * 1000;
 }
 
-/** timestamp_ms を UTC 日付文字列に変換する */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/** timestamp_ms を JST 日付文字列に変換する */
 function msToDateStr(ms: number): string {
-	return new Date(ms).toISOString().slice(0, 10);
+	return new Date(ms + JST_OFFSET_MS).toISOString().slice(0, 10);
 }
 
 describe("getOverviewStats", () => {

--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -133,7 +133,7 @@ export async function getDailyCosts(
 	const result = await db
 		.prepare(
 			`SELECT
-				date(a.timestamp_ms / 1000, 'unixepoch') as date,
+				date(a.timestamp_ms / 1000, 'unixepoch', '+9 hours') as date,
 				a.model,
 				SUM(a.cost_usd) as cost,
 				COUNT(*) as calls
@@ -165,7 +165,7 @@ export async function getDailyTokens(
 	const result = await db
 		.prepare(
 			`SELECT
-				date(a.timestamp_ms / 1000, 'unixepoch') as date,
+				date(a.timestamp_ms / 1000, 'unixepoch', '+9 hours') as date,
 				SUM(a.input_tokens) as input_tokens,
 				SUM(a.output_tokens) as output_tokens,
 				SUM(a.cache_read_tokens) as cache_read_tokens,


### PR DESCRIPTION
## Summary
- `formatTime()` に JST オフセット (+9h) を追加し、セッション一覧等の時刻表示を JST 化
- 日別集計 SQL (`getDailyCosts`, `getDailyTokens`) に `'+9 hours'` 修飾子を追加し、チャートの日付区切りを JST 基準に変更
- DB の `timestamp_ms` は UTC のまま維持（表示層のみ変換）

Closes #18

## Test plan
- [x] `pnpm test` - 全128テストパス
- [x] `pnpm typecheck` - 型チェックパス
- [x] `pnpm lint` - lint パス
- [x] 本番デプロイ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)